### PR TITLE
Handle CAN receive timeouts gracefully

### DIFF
--- a/python/isotp.py
+++ b/python/isotp.py
@@ -8,6 +8,10 @@ except Exception:  # pylint: disable=broad-except
 
 DEBUG = False
 
+
+def _is_timeout_exception(exc):
+  return isinstance(exc, TimeoutError) or (isinstance(exc, Exception) and len(exc.args) == 1 and exc.args[0] == "timeout")
+
 def _is_spi_nack(exc):
   return PandaSpiNackResponse is not None and isinstance(exc, PandaSpiNackResponse)
 
@@ -30,7 +34,12 @@ def panda_send(panda, addr, dat, bus):
   _call_can_send(panda, addr, dat, bus)
 
 def panda_recv(panda):
-  x = panda.can_recv()
+  try:
+    x = panda.can_recv()
+  except Exception as exc:  # pylint: disable=broad-except
+    if _is_timeout_exception(exc):
+      return []
+    raise
   #for y in x:
     #print(f"RECV: bus: {y[3]}, addr: {y[0]}, data: {binascii.hexlify(y[2])}")
   #  if y[0] in (673, 681, 1, 2):
@@ -94,7 +103,11 @@ def recv(panda, cnt, addr, nbus):
   ret = []
 
   while len(ret) < cnt:
-    kmsgs += panda_recv(panda)
+    new_msgs = panda_recv(panda)
+    if not new_msgs:
+      time.sleep(0.01)
+      continue
+    kmsgs += new_msgs
     nmsgs = []
     for msg in kmsgs:
       if len(msg) == 4:


### PR DESCRIPTION
## Summary
- add timeout detection helper for panda CAN receive calls
- treat CAN receive timeouts as empty reads and avoid tight spin loops

## Testing
- not run (hardware-dependent)

------
https://chatgpt.com/codex/tasks/task_e_68dc49992690832381636dee6261925f