### PR TITLE
Raise timeout errors

### DIFF
--- a/python/__init__.py
+++ b/python/__init__.py
@@ -58,7 +58,7 @@ class BootLoaderHandle(object):
 
     def _handle_timeout(signum, frame):
       # will happen on reset
-      raise Exception("timeout")
+      raise TimeoutError("timeout")
 
     signal.signal(signal.SIGALRM, _handle_timeout)
     signal.alarm(1)
@@ -96,7 +96,7 @@ class FilterHandle(object):
 
     def _handle_timeout(signum, frame):
       # will happen on reset
-      raise Exception("timeout")
+      raise TimeoutError("timeout")
 
     signal.signal(signal.SIGALRM, _handle_timeout)
     signal.alarm(1)


### PR DESCRIPTION
## Summary
- raise TimeoutError from the flashing signal handlers so timeout detection treats it as benign

## Testing
- not run (hardware-dependent)


------
https://chatgpt.com/codex/tasks/task_e_68dc49992690832381636dee6261925f