### PR TITLE
Improve bootloader flash timeout handling

### DIFF
--- a/python/__init__.py
+++ b/python/__init__.py
@@ -50,24 +50,48 @@ def panda_isotp_recv(pd, addr, bus=0, sendaddr=None, subaddr=None, bs=0, st=0):
   return isotp_recv(pd, addr, bus, sendaddr, subaddr, bs, st)
 
 class BootLoaderHandle(object):
+  _DEFAULT_TIMEOUT = 1.0
+  _TIME_SLICE = 1.0
+
   def __init__(self, panda):
     self.panda = panda
 
-  def transact(self, dat):
-    panda_isotp_send(self.panda, 1, dat, 0, recvaddr=2)
-
+  def _recv_with_timeout(self, timeout):
     def _handle_timeout(signum, frame):
       # will happen on reset
       raise TimeoutError("timeout")
 
-    signal.signal(signal.SIGALRM, _handle_timeout)
-    signal.alarm(1)
+    prev_handler = signal.signal(signal.SIGALRM, _handle_timeout)
+    prev_timer = signal.setitimer(signal.ITIMER_REAL, timeout, 0)
     try:
-      ret = panda_isotp_recv(self.panda, 2, 0, sendaddr=1, subaddr=None, bs=1, st=20)
+      return panda_isotp_recv(self.panda, 2, 0, sendaddr=1, subaddr=None, bs=1, st=20)
     finally:
-      signal.alarm(0)
+      signal.setitimer(signal.ITIMER_REAL, prev_timer[0], prev_timer[1])
+      signal.signal(signal.SIGALRM, prev_handler)
 
-    return ret
+  def transact(self, dat, timeout=0):
+    panda_isotp_send(self.panda, 1, dat, 0, recvaddr=2)
+
+    total_timeout = self._DEFAULT_TIMEOUT if timeout is None or timeout <= 0 else float(timeout)
+    deadline = time.monotonic() + total_timeout
+    last_exc = None
+
+    while True:
+      remaining = deadline - time.monotonic()
+      if remaining <= 0:
+        error = TimeoutError(f"timeout waiting for bootloader response after {total_timeout:.3f}s")
+        raise error from last_exc
+
+      window = min(remaining, self._TIME_SLICE)
+      # avoid scheduling a zero length timer which would raise immediately
+      window = max(window, 1e-6)
+
+      try:
+        return self._recv_with_timeout(window)
+      except TimeoutError as exc:
+        last_exc = exc
+        # Allow the bootloader a chance to respond until the overall deadline expires.
+        continue
 
   def controlWrite(self, request_type, request, value, index, data, timeout=0):
     # ignore data in reply, panda doesn't use it
@@ -75,17 +99,17 @@ class BootLoaderHandle(object):
 
   def controlRead(self, request_type, request, value, index, length, timeout=0):
     dat = struct.pack("HHBBHHH", 0, 0, request_type, request, value, index, length)
-    return self.transact(dat)
+    return self.transact(dat, timeout)
 
   def bulkWrite(self, endpoint, data, timeout=0):
     if len(data) > 0x10:
       raise ValueError("Data must not be longer than 0x10")
     dat = struct.pack("HH", endpoint, len(data)) + data
-    return self.transact(dat)
+    return self.transact(dat, timeout)
 
   def bulkRead(self, endpoint, length, timeout=0):
     dat = struct.pack("HH", endpoint, 0)
-    return self.transact(dat)
+    return self.transact(dat, timeout)
 
 class FilterHandle(object):
   def __init__(self, panda):


### PR DESCRIPTION
## Summary
- split bootloader receive waits into short polling windows so long flash operations can keep retrying until the overall timeout expires
- centralize SIGALRM handling for bootloader transactions to reliably restore any pre-existing timers

## Testing
- not run (hardware dependent)


------
https://chatgpt.com/codex/tasks/task_e_68dc4d1d20c08323bc33b792afa5b53f